### PR TITLE
Reading the default value of an Annotation attribute when it exists.

### DIFF
--- a/compozitor-processor/src/main/java/compozitor/processor/core/interfaces/AnnotationModel.java
+++ b/compozitor-processor/src/main/java/compozitor/processor/core/interfaces/AnnotationModel.java
@@ -13,7 +13,7 @@ public class AnnotationModel extends Model<AnnotationMirror> {
 
   public AnnotationValue getValue(String key) {
     Map<? extends ExecutableElement, ? extends AnnotationValue> values =
-        this.element.getElementValues();
+        context.getElementValuesWithDefaults(this.element);
     for (ExecutableElement keyElement : values.keySet()) {
       if (keyElement.getSimpleName().contentEquals(key)) {
         return values.get(keyElement);

--- a/compozitor-processor/src/main/java/compozitor/processor/core/test/MethodAnnotationWithAttributes.java
+++ b/compozitor-processor/src/main/java/compozitor/processor/core/test/MethodAnnotationWithAttributes.java
@@ -1,0 +1,14 @@
+package compozitor.processor.core.test;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.SOURCE)
+@interface MethodAnnotationWithAttributes {
+    String firstName();
+
+    String[] surnames() default {};
+}

--- a/compozitor-processor/src/test/java/compozitor/processor/core/application/FieldProcessor.java
+++ b/compozitor-processor/src/test/java/compozitor/processor/core/application/FieldProcessor.java
@@ -26,7 +26,7 @@ public class FieldProcessor extends AnnotationProcessor {
 	
 	@Override
     public Set<String> getSupportedAnnotationTypes() {
-      Set<String> types = new HashSet<String>();
+      Set<String> types = new HashSet<>();
       types.add("compozitor.processor.core.test.FieldAnnotation");
       return types;
     }

--- a/compozitor-processor/src/test/java/compozitor/processor/core/application/MethodProcessor.java
+++ b/compozitor-processor/src/test/java/compozitor/processor/core/application/MethodProcessor.java
@@ -26,7 +26,7 @@ public class MethodProcessor extends AnnotationProcessor {
 	
 	@Override
     public Set<String> getSupportedAnnotationTypes() {
-      Set<String> types = new HashSet<String>();
+      Set<String> types = new HashSet<>();
       types.add("compozitor.processor.core.test.MethodAnnotation");
       return types;
     }

--- a/compozitor-processor/src/test/java/compozitor/processor/core/application/MethodProcessorWithAttributes.java
+++ b/compozitor-processor/src/test/java/compozitor/processor/core/application/MethodProcessorWithAttributes.java
@@ -1,0 +1,49 @@
+package compozitor.processor.core.application;
+
+import compozitor.processor.core.interfaces.AnnotationModel;
+import compozitor.processor.core.interfaces.AnnotationProcessor;
+import compozitor.processor.core.interfaces.FieldModel;
+import compozitor.processor.core.interfaces.MethodModel;
+import compozitor.processor.core.interfaces.TypeModel;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import javax.lang.model.element.AnnotationMirror;
+import org.junit.Assert;
+
+public class MethodProcessorWithAttributes extends AnnotationProcessor {
+	private static final String ANNOTATION_CLASS_NAME = "compozitor.processor.core.test.MethodAnnotationWithAttributes";
+
+	@Override
+	protected void process(TypeModel model) {
+		Assert.fail();
+	}
+
+	@Override
+	protected void process(FieldModel model) {
+		Assert.fail();
+	}
+
+	@Override
+	protected void process(MethodModel model) {
+		Assert.assertNotNull(model);
+
+		final TypeModel annotationType = javaTypes.getAnnotationType(ANNOTATION_CLASS_NAME);
+
+		final AnnotationModel annotationModel = model.getAnnotations()
+				.get(annotation -> annotation.instanceOf(annotationType))
+				.get();
+
+		Assert.assertEquals("first", annotationModel.getValue("firstName").getValue());
+		final List<AnnotationMirror> surnames = (List<AnnotationMirror>) annotationModel
+				.getValue("surnames").getValue();
+		Assert.assertTrue(surnames.isEmpty());
+	}
+	
+	@Override
+    public Set<String> getSupportedAnnotationTypes() {
+      Set<String> types = new HashSet<>();
+      types.add(ANNOTATION_CLASS_NAME);
+      return types;
+    }
+}

--- a/compozitor-processor/src/test/java/compozitor/processor/core/application/TypeProcessor.java
+++ b/compozitor-processor/src/test/java/compozitor/processor/core/application/TypeProcessor.java
@@ -26,7 +26,7 @@ public class TypeProcessor extends AnnotationProcessor {
 	
 	@Override
 	public Set<String> getSupportedAnnotationTypes() {
-	  Set<String> types = new HashSet<String>();
+	  Set<String> types = new HashSet<>();
 	  types.add("compozitor.processor.core.test.TypeAnnotation");
 	  return types;
 	}

--- a/compozitor-processor/src/test/java/compozitor/processor/core/interfaces/CompozitorProcessorTest.java
+++ b/compozitor-processor/src/test/java/compozitor/processor/core/interfaces/CompozitorProcessorTest.java
@@ -1,5 +1,6 @@
 package compozitor.processor.core.interfaces;
 
+import compozitor.processor.core.application.MethodProcessorWithAttributes;
 import org.junit.Assert;
 import org.junit.Test;
 import com.google.testing.compile.Compilation;
@@ -30,6 +31,14 @@ public class CompozitorProcessorTest {
     Compilation compilation =
         CompilationBuilder.create().withJavaSource("compozitor/processor/core/test/TypeModel.java")
             .withProcessors(new MethodProcessor()).build();
+    Assert.assertEquals(Status.SUCCESS, compilation.status());
+  }
+
+  @Test
+  public void givenTypeModelAnnotatedWithMethodAnnotationWithAttributesWhenCompileThenProcessType() {
+    Compilation compilation =
+        CompilationBuilder.create().withJavaSource("compozitor/processor/core/test/TypeModel.java")
+            .withProcessors(new MethodProcessorWithAttributes()).build();
     Assert.assertEquals(Status.SUCCESS, compilation.status());
   }
 

--- a/compozitor-processor/src/test/resources/compozitor/processor/core/test/TypeModel.java
+++ b/compozitor-processor/src/test/resources/compozitor/processor/core/test/TypeModel.java
@@ -19,4 +19,9 @@ public class TypeModel {
 	public void doSomething(List<String> values) {
 		
 	}
+
+	@MethodAnnotationWithAttributes(firstName = "first")
+	public void doSomethingWithAttributes() {
+
+	}
 }


### PR DESCRIPTION
The current behavior was to return null, i.e. not compute the attribute key.